### PR TITLE
Replaced unzip package for decompress

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "url": "https://github.com/gillbeits/gulp-fontello.git"
   },
   "dependencies": {
+    "decompress": "^3.0.0",
     "gulp-util": "^3.0.4",
     "needle": "git@github.com:dailyraisin/needle.git",
     "path": "^0.11.14",
-    "through2": "^0.6.3",
-    "unzip": "^0.1.11"
+    "through2": "^0.6.3"
   },
   "keywords": [
     "fontello",


### PR DESCRIPTION
I'm still getting errors from the updated plugin
The retry is a good addition, but I think is not the issue with the `gulp-fontello` plugin.
The problem resides in the unzip package, please check github issues [#60](https://github.com/EvanOxfeld/node-unzip/issues/60), [#65](https://github.com/EvanOxfeld/node-unzip/issues/65) [#73](https://github.com/EvanOxfeld/node-unzip/issues/73), [#89](https://github.com/EvanOxfeld/node-unzip/issues/89)

This PR replaces the `unzip` package (which is not being actively mantained) with [decompress](https://www.npmjs.com/package/decompress)
