### PR TITLE
Added fix for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var needleOptions = {
 };
 
 const PLUGIN_NAME = 'gulp-fontello';
+var isWindows = /^win/.test(process.platform);
 
 function addMultipart (obj) {
     obj.multipart = true;
@@ -70,7 +71,15 @@ function fontello () {
                 function (cb) {
                   if(chunks.length > 0){
                     dirName = (_ref = path.dirname(pathName).match(/\/([^\/]*)$/)) != null ? _ref[1] : void 0;
-                    fileName = path.basename(pathName);
+
+                    if(isWindows) {
+                      fileName = path.posix.basename(pathName).split('\\');
+                      fileName.shift(); //removes temporary folder
+                      fileName = fileName.join('\\');
+                    } else {
+                      fileName = path.basename(pathName);
+                    }
+
                     entry.path = fileName;
 
                     var file = new $.File({


### PR DESCRIPTION
Hello, 
There's some confusion related to the output destination of files on Windows OS. 
That is because Node's <a href="https://nodejs.org/api/path.html#path_path_basename_path_ext">path.basename</a> has been used.  There is a difference in return value that depends on the type of OS whether is POSIX or Windows. More information about that you may find <a href="https://nodejs.org/api/path.html#path_windows_vs_posix">here.</a>

To avoid such confusion this patch was introduced. 
